### PR TITLE
Update Vote Manager to cache votes

### DIFF
--- a/src/main/java/com/google/step/datamanager/VoteCache.java
+++ b/src/main/java/com/google/step/datamanager/VoteCache.java
@@ -1,0 +1,47 @@
+package com.google.step.datamanager;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+
+public class VoteCache {
+  // time the vote can live for in seconds
+  private final long TIME_TO_LIVE = 3600;
+
+  private final DatastoreService datastore;
+
+  public VoteCache() {
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  public VoteWithExpiry readVotes(long dealId) {
+    Query query =
+        new Query("VoteCache")
+            .setFilter(new Query.FilterPredicate("dealId", Query.FilterOperator.EQUAL, dealId));
+
+    PreparedQuery results = datastore.prepare(query);
+    Entity entity = results.asSingleEntity();
+
+    if (entity == null) {
+      return new VoteWithExpiry(0, true);
+    }
+
+    long votes = (long) entity.getProperty("votes");
+    long expiryTime = (long) entity.getProperty("expiry");
+    boolean isExpired = System.currentTimeMillis() / 1000 > expiryTime;
+
+    return new VoteWithExpiry(votes, isExpired);
+  }
+
+  public void saveVotes(long dealId, long votes) {
+    Entity entity = new Entity("VoteCache");
+    entity.setProperty("dealId", dealId);
+    entity.setProperty("votes", votes);
+    long expiryTime = System.currentTimeMillis() / 1000 + TIME_TO_LIVE;
+    entity.setProperty("expiry", expiryTime);
+
+    datastore.put(entity);
+  }
+}

--- a/src/main/java/com/google/step/datamanager/VoteCache.java
+++ b/src/main/java/com/google/step/datamanager/VoteCache.java
@@ -33,7 +33,7 @@ public class VoteCache {
     return new VoteWithExpiry(votes, isExpired);
   }
 
-  public void saveVotes(long dealId, long votes) {
+  public void saveVotes(long dealId, int votes) {
     Entity entity = new Entity("VoteCache", dealId);
     entity.setProperty("votes", votes);
     long expiryTime = System.currentTimeMillis() / 1000 + TIME_TO_LIVE;

--- a/src/main/java/com/google/step/datamanager/VoteCache.java
+++ b/src/main/java/com/google/step/datamanager/VoteCache.java
@@ -41,4 +41,9 @@ public class VoteCache {
 
     datastore.put(entity);
   }
+
+  public void deleteCache(long dealId) {
+    Key key = KeyFactory.createKey("VoteCache", dealId);
+    datastore.delete(key);
+  }
 }

--- a/src/main/java/com/google/step/datamanager/VoteManagerDatastore.java
+++ b/src/main/java/com/google/step/datamanager/VoteManagerDatastore.java
@@ -20,6 +20,11 @@ public class VoteManagerDatastore implements VoteManager {
     voteCache = new VoteCache();
   }
 
+  public VoteManagerDatastore(VoteCache voteCache) {
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    this.voteCache = voteCache;
+  }
+
   private int computeVotes(long dealId) {
     Filter dealFilter = new FilterPredicate("deal", FilterOperator.EQUAL, dealId);
     Query query = new Query("Vote").setFilter(dealFilter);

--- a/src/main/java/com/google/step/datamanager/VoteManagerDatastore.java
+++ b/src/main/java/com/google/step/datamanager/VoteManagerDatastore.java
@@ -69,8 +69,8 @@ public class VoteManagerDatastore implements VoteManager {
     entity.setProperty("dir", dir);
     datastore.put(entity);
 
-    // re-calculate votes for cache
-    voteCache.saveVotes(dealId, computeVotes(dealId));
+    // delete old cache
+    voteCache.deleteCache(dealId);
   }
 
   @Override

--- a/src/main/java/com/google/step/datamanager/VoteWithExpiry.java
+++ b/src/main/java/com/google/step/datamanager/VoteWithExpiry.java
@@ -1,0 +1,11 @@
+package com.google.step.datamanager;
+
+public class VoteWithExpiry {
+  public final long votes;
+  public final boolean isExpired;
+
+  public VoteWithExpiry(long votes, boolean isExpired) {
+    this.votes = votes;
+    this.isExpired = isExpired;
+  }
+}

--- a/src/main/java/com/google/step/datamanager/VoteWithExpiry.java
+++ b/src/main/java/com/google/step/datamanager/VoteWithExpiry.java
@@ -1,10 +1,10 @@
 package com.google.step.datamanager;
 
 public class VoteWithExpiry {
-  public final long votes;
+  public final int votes;
   public final boolean isExpired;
 
-  public VoteWithExpiry(long votes, boolean isExpired) {
+  public VoteWithExpiry(int votes, boolean isExpired) {
     this.votes = votes;
     this.isExpired = isExpired;
   }

--- a/src/test/java/com/google/step/datamanager/VoteManagerDatastoreTest.java
+++ b/src/test/java/com/google/step/datamanager/VoteManagerDatastoreTest.java
@@ -121,4 +121,15 @@ public final class VoteManagerDatastoreTest {
 
     verify(mockVoteCache).saveVotes(eq(DEAL_ID_A), anyInt());
   }
+
+  @Test
+  public void testCache_deleteCache() {
+    VoteCache mockVoteCache = mock(VoteCache.class);
+    when(mockVoteCache.readVotes(DEAL_ID_A)).thenReturn(new VoteWithExpiry(0, true));
+
+    VoteManagerDatastore voteManagerDatastore = new VoteManagerDatastore(mockVoteCache);
+    voteManagerDatastore.vote(USER_ID_A, DEAL_ID_A, 1);
+
+    verify(mockVoteCache).deleteCache(DEAL_ID_A);
+  }
 }


### PR DESCRIPTION
the number of votes for each deal will be stored in a datastore as cache and expires 1 hour later. Future queries do not need to loop through and count the number of votes. If the vote changes, the cache is deleted.